### PR TITLE
Add basic ZAP github workflow - TEST PR

### DIFF
--- a/.github/workflows/zap-pen-test.yaml
+++ b/.github/workflows/zap-pen-test.yaml
@@ -11,4 +11,4 @@ jobs:
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.2.0
         with:
-          target: "https://give-dev.app.cloud.gov"
+          target: "https://give-dev.app.cloud.gov/ipp/enrollment"

--- a/.github/workflows/zap-pen-test.yaml
+++ b/.github/workflows/zap-pen-test.yaml
@@ -11,4 +11,4 @@ jobs:
       - name: ZAP Scan
         uses: zaproxy/action-full-scan@v0.2.0
         with:
-          target: "https://give-dev.app.cloud.gov/ipp/enrollment"
+          target: "https://give-dev.app.cloud.gov/"

--- a/.github/workflows/zap-pen-test.yaml
+++ b/.github/workflows/zap-pen-test.yaml
@@ -1,0 +1,14 @@
+---
+# This workflow will run a series of penetration tests against the GIVE API Gateway
+
+on: [pull_request]
+
+jobs:
+  zap_scan:
+    runs-on: ubuntu-latest
+    name: Scan the API Gateway
+    steps:
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.2.0
+        with:
+          target: "https://give-dev.app.cloud.gov"


### PR DESCRIPTION
OWASP ZAP now added to the GIVE API Gateway build/deployment workflow.
Runs basic tests against the dev url.